### PR TITLE
Revert unjustified surname removal

### DIFF
--- a/data/names/en.json
+++ b/data/names/en.json
@@ -3606,6 +3606,7 @@
       "Cook",
       "Cooke",
       "Cooley",
+      "Coon",
       "Cooney",
       "Cooper",
       "Cope",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

#### Purpose of change

https://github.com/CleverRaven/Cataclysm-DDA/pull/62144 removed "Coon" surname from a list of possible surnames. Regardless of what DDA devs may be thinking about it, this is an attack against all the people with the surname Coon, which is unacceptable and won't be tolerated.

Removed town names won't be restored because there are indeed no towns with such names in New England.

#### Additional context

List of real-life people with the surname Coon, in case anyone has any doubt about it: https://en.wikipedia.org/wiki/Coon_(surname)