### PR TITLE
Re-implement cauterizing, add mangling and suturing

### DIFF
--- a/data/json/EraOfDecay/items/item_actions.json
+++ b/data/json/EraOfDecay/items/item_actions.json
@@ -3,5 +3,20 @@
     "type": "item_action",
     "id": "LAUDANUM",
     "name": { "str": "Take" }
+  },
+  {
+    "type": "item_action",
+    "id": "cauterize",
+    "name": { "str": "Cauterize a wound" }
+  },
+  {
+    "type": "item_action",
+    "id": "SUTURE",
+    "name": { "str": "Suture wound" }
+  },
+  {
+    "type": "item_action",
+    "id": "MANGLE",
+    "name": { "str": "Mangle yourself" }
   }
 ]

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -625,7 +625,8 @@
         "skill": "fabrication",
         "cost_scaling": 0.1,
         "move_cost": 1500
-      }
+      },
+      { "flame": false, "type": "cauterize" }
     ],
     "flags": [ "ALLOWS_REMOTE_USE" ],
     "pocket_data": [
@@ -1137,7 +1138,8 @@
         "skill": "fabrication",
         "cost_scaling": 0.1,
         "move_cost": 1500
-      }
+      },
+      { "flame": false, "type": "cauterize" }
     ],
     "flags": [ "ALLOWS_REMOTE_USE" ],
     "pocket_data": [
@@ -1153,7 +1155,7 @@
     "id": "soldering_iron",
     "type": "TOOL",
     "name": { "str": "soldering iron" },
-    "description": "This is a device with a metal tip that can get very hot.  It is necessary for advanced electronics crafting.",
+    "description": "This is a device with a metal tip that can get very hot.  It is necessary for advanced electronics crafting.  You could also use it to cauterize bleeding wounds, if you had to.",
     "weight": "181 g",
     "volume": "100 ml",
     "longest_side": "25 cm",
@@ -1174,7 +1176,8 @@
         "skill": "fabrication",
         "cost_scaling": 0.1,
         "move_cost": 1500
-      }
+      },
+      { "flame": false, "type": "cauterize" }
     ],
     "flags": [ "SPEAR", "BELT_CLIP", "ALLOWS_REMOTE_USE", "WATER_BREAK" ],
     "pocket_data": [
@@ -1285,7 +1288,8 @@
         "skill": "fabrication",
         "cost_scaling": 0.1,
         "move_cost": 1000
-      }
+      },
+      { "flame": false, "type": "cauterize" }
     ],
     "qualities": [
       [ "SAW_W", 1 ],

--- a/data/json/npcs/hints.json
+++ b/data/json/npcs/hints.json
@@ -126,7 +126,7 @@
       "What's the difference between a good and a bad choke point?  The good one has another back door behind you.",
       "So, methinks: if you could convince the cop-bots that you are their superior…",
       "You'd be surprised how many items can be disassembled into their components.  A guy around here, McSomething whatever his name is, is a master at this.",
-      "A soldering iron can be an aspiring mechanic's best friend.",
+      "A soldering iron can be an aspiring mechanic's best friend.  You can also cauterize a bleeding wound with it, but as many people died as lived from that treatment, so I guess it's a last resort.",
       "I've seen some folks running with freshly installed CBMs.  That means there is a way to get them from places other than ransacked shops.  Maybe that explains those cut-up bodies I've seen around.",
       "I'm fed up with smoked meat, but it lasts so long.  Well… if I had more heart for learning cooking I guess I'd be able to diversify my food without sacrificing its shelf life.",
       "Tricky Joe was hanged for his inventive ways of killing zombies.  Yeah, burning down a building to smoke few hordes is ok, but burning a whole town with all the loot certainly is not.",

--- a/data/json/tool_qualities.json
+++ b/data/json/tool_qualities.json
@@ -3,7 +3,7 @@
     "type": "tool_quality",
     "id": "CUT",
     "name": { "str": "cutting" },
-    "usages": [ [ 1, [ "salvage", "inscribe" ] ] ]
+    "usages": [ [ 1, [ "salvage", "inscribe", "cauterize", "MANGLE" ] ] ]
   },
   {
     "type": "tool_quality",
@@ -14,7 +14,7 @@
     "type": "tool_quality",
     "id": "CUT_FINE",
     "name": { "str": "fine cutting" },
-    "usages": [ [ 1, [ "salvage", "inscribe" ] ] ]
+    "usages": [ [ 1, [ "salvage", "inscribe", "cauterize", "MANGLE" ] ] ]
   },
   {
     "type": "tool_quality",
@@ -225,7 +225,8 @@
   {
     "type": "tool_quality",
     "id": "SEW",
-    "name": { "str": "sewing" }
+    "name": { "str": "sewing" },
+    "usages": [ [ 1, [ "SUTURE" ] ] ]
   },
   {
     "type": "tool_quality",
@@ -352,7 +353,7 @@
     "id": "FABRIC_CUT",
     "//": "A tool that shares a large number of qualities with cutting tools, with the added benefit of being suitable for cutting fabric to patterned shapes for tailoring.",
     "name": { "str": "fabric cutting" },
-    "usages": [ [ 1, [ "salvage", "inscribe" ] ] ]
+    "usages": [ [ 1, [ "salvage", "inscribe", "cauterize" ] ] ]
   },
   {
     "type": "tool_quality",

--- a/data/mods/Magiclysm/items/enchanted_misc.json
+++ b/data/mods/Magiclysm/items/enchanted_misc.json
@@ -30,7 +30,8 @@
         "menu_text": "Activate torch mode",
         "moves": 150
       },
-      { "type": "firestarter" }
+      { "type": "firestarter" },
+      { "flame": false, "type": "cauterize" }
     ]
   },
   {

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -844,7 +844,7 @@
     "id": "test_soldering_iron",
     "type": "TOOL",
     "name": "TEST soldering iron",
-    "description": "This is a device with a metal tip that can get very hot.  It is necessary for advanced electronics crafting.",
+    "description": "This is a device with a metal tip that can get very hot.  It is necessary for advanced electronics crafting.  You could also use it to cauterize bleeding wounds, if you had to.",
     "weight": "181 g",
     "volume": "500 ml",
     "price": 1000,
@@ -863,7 +863,8 @@
         "skill": "fabrication",
         "cost_scaling": 0.1,
         "move_cost": 1500
-      }
+      },
+      { "flame": false, "type": "cauterize" }
     ],
     "flags": [ "SPEAR", "BELT_CLIP", "ALLOWS_REMOTE_USE" ],
     "pocket_data": [

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -1379,7 +1379,7 @@ These flags apply to the `use_action` field, instead of the `flags` field.
 - ```SMOKEBOMB``` Pull the pin on a smoke bomb.
 - ```SOLARPACK_OFF``` Fold solar backpack array.
 - ```SOLARPACK``` Unfold solar backpack array.
-- ```SOLDER_WELD``` Solder or weld items.
+- ```SOLDER_WELD``` Solder or weld items, or cauterize bleeding wounds.
 - ```SPRAY_CAN``` Graffiti the town.
 - ```SURVIVORMAP``` Learn of local points-of-interest that can help you survive, and show roads.
 - ```TAZER``` Shock someone or something.

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -2491,7 +2491,7 @@ Examples of various usages syntax:
 ```C++
 "usages": [ [ 1, [ "PICK_LOCK" ] ] ]
 "usages": [ [ 2, [ "LUMBER" ] ] ]
-"usages": [ [ 1, [ "salvage", "inscribe"] ] ]
+"usages": [ [ 1, [ "salvage", "inscribe", "cauterize" ] ] ]
 "usages": [ [ 2, [ "HACKSAW", "saw_barrel" ] ] ]
 "usages": [ [ 1, [ "CHOP_TREE", "CHOP_LOGS" ] ], [ 2, [ "LUMBER" ] ] ]
 ```
@@ -3887,6 +3887,10 @@ The contents of use_action fields can either be a string indicating a built-in f
         "steel",
         "silver"
     ]
+},
+"use_action": {
+    "type": "cauterize", // Cauterize the character.
+    "flame": true // If true, the character needs 4 charges of fire (e.g. from a lighter) to do this action, if false, the charges of the item itself are used.
 },
 "use_action": {
     "type": "fireweapon_off", // Activate a fire based weapon.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -430,6 +430,7 @@ static const trait_id trait_LEG_TENT_BRACE( "LEG_TENT_BRACE" );
 static const trait_id trait_LIGHTSTEP( "LIGHTSTEP" );
 static const trait_id trait_LOVES_BOOKS( "LOVES_BOOKS" );
 static const trait_id trait_MASOCHIST( "MASOCHIST" );
+static const trait_id trait_MASOCHIST_MED( "MASOCHIST_MED" );
 static const trait_id trait_MORE_PAIN( "MORE_PAIN" );
 static const trait_id trait_MORE_PAIN2( "MORE_PAIN2" );
 static const trait_id trait_MORE_PAIN3( "MORE_PAIN3" );
@@ -1204,6 +1205,12 @@ bool Character::sight_impaired() const
              !has_effect( effect_contacts ) &&
              !has_flag( json_flag_ENHANCED_VISION ) ) ||
            has_trait( trait_PER_SLIME ) || is_blind();
+}
+
+bool Character::enjoys_pain() const
+{
+    return ( ( has_trait( trait_MASOCHIST ) && get_perceived_pain() < 20 ) ||
+             has_trait( trait_MASOCHIST_MED ) || has_trait( trait_CENOBITE ) ) && !has_trait( trait_NOPAIN );
 }
 
 bool Character::has_alarm_clock() const

--- a/src/character.h
+++ b/src/character.h
@@ -690,6 +690,8 @@ class Character : public Creature, public visitable
         int  clairvoyance() const;
         /** Returns true if the player has some form of impaired sight */
         bool sight_impaired() const;
+        /** Returns true if the player would get morale bonus for being in more pain */
+        bool enjoys_pain() const;
         /** Returns true if the player or their vehicle has an alarm clock */
         bool has_alarm_clock() const;
         /** Returns true if the player or their vehicle has a watch */

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1660,6 +1660,7 @@ void Item_factory::init()
     add_iuse( "MARLOSS_SEED", &iuse::marloss_seed );
     add_iuse( "MA_MANUAL", &iuse::ma_manual );
     add_iuse( "MANAGE_EXOSUIT", &iuse::manage_exosuit );
+    add_iuse( "MANGLE", &iuse::mangle );
     add_iuse( "MEDITATE", &iuse::meditate );
     add_iuse( "METH", &iuse::meth );
     add_iuse( "MININUKE", &iuse::mininuke );
@@ -1710,6 +1711,7 @@ void Item_factory::init()
     add_iuse( "SPRAY_CAN", &iuse::spray_can );
     add_iuse( "STIMPACK", &iuse::stimpack );
     add_iuse( "STRONG_ANTIBIOTIC", &iuse::strong_antibiotic );
+    add_iuse( "SUTURE", &iuse::suture );
     add_iuse( "TAZER", &iuse::tazer );
     add_iuse( "TAZER2", &iuse::tazer2 );
     add_iuse( "TELEPORT", &iuse::teleport );
@@ -1740,6 +1742,7 @@ void Item_factory::init()
     add_iuse( "VOLTMETER", &iuse::voltmeter );
 
     add_actor( std::make_unique<ammobelt_actor>() );
+    add_actor( std::make_unique<cauterize_actor>() );
     add_actor( std::make_unique<consume_drug_iuse>() );
     add_actor( std::make_unique<delayed_transform_iuse>() );
     add_actor( std::make_unique<explosion_iuse>() );

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -151,6 +151,7 @@ cata::optional<int> ebooksave( Character *, item *, bool, const tripoint & );
 cata::optional<int> ebookread( Character *, item *, bool, const tripoint & );
 cata::optional<int> makemound( Character *, item *, bool, const tripoint & );
 cata::optional<int> manage_exosuit( Character *, item *, bool, const tripoint & );
+cata::optional<int> mangle( Character *, item *, bool, const tripoint & );
 cata::optional<int> melatonin_tablet( Character *, item *, bool, const tripoint & );
 cata::optional<int> mininuke( Character *, item *, bool, const tripoint & );
 cata::optional<int> molotov_lit( Character *, item *, bool, const tripoint & );
@@ -189,6 +190,7 @@ cata::optional<int> solarpack_off( Character *, item *, bool, const tripoint & )
 cata::optional<int> spray_can( Character *, item *, bool, const tripoint & );
 cata::optional<int> stimpack( Character *, item *, bool, const tripoint & );
 cata::optional<int> strong_antibiotic( Character *, item *, bool, const tripoint & );
+cata::optional<int> suture( Character *, item *, bool, const tripoint & );
 cata::optional<int> talking_doll( Character *, item *, bool, const tripoint & );
 cata::optional<int> tazer( Character *, item *, bool, const tripoint & );
 cata::optional<int> tazer2( Character *, item *, bool, const tripoint & );

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -551,6 +551,26 @@ class inscribe_actor : public iuse_actor
 };
 
 /**
+ * Cauterizes a wounded/masochistic survivor
+ */
+class cauterize_actor : public iuse_actor
+{
+    public:
+        // Use flame. If false, uses item charges instead.
+        bool flame = true;
+
+        static bool cauterize_effect( Character &p, item &it, bool force );
+
+        explicit cauterize_actor( const std::string &type = "cauterize" ) : iuse_actor( type ) {}
+
+        ~cauterize_actor() override = default;
+        void load( const JsonObject &obj ) override;
+        cata::optional<int> use( Character &, item &, bool, const tripoint & ) const override;
+        ret_val<void> can_use( const Character &, const item &, bool, const tripoint & ) const override;
+        std::unique_ptr<iuse_actor> clone() const override;
+};
+
+/**
  * Try to turn on a burning melee weapon
  * Not iuse_transform, because they don't have that much in common
  */


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Re-implement cauterizing, add mangling and suturing"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/pull/62539 removed cauterization mechanics from DDA. This PR re-implements cauterization as a functional and more realistic (which means even less useful) option for stopping bleeding.

Also implements wound suturing mechanics (likewise for stopping bleeding), and mangling action to provide morale bonus to masochist characters.