### PR TITLE
Additional messages in log

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -47,6 +47,7 @@
 #include "morale_types.h"
 #include "mtype.h"
 #include "npc.h"
+#include "options.h"
 #include "output.h"
 #include "point.h"
 #include "projectile.h"
@@ -1074,13 +1075,14 @@ void Creature::deal_projectile_attack( Creature *source, dealt_projectile_attack
             add_msg_player_or_npc(
                 m_warning,
                 _( "You avoid %s projectile!" ),
-                _( "<npcname> avoids %s projectile." ),
+                get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? _( "<npcname> avoids %s projectile." ) : "",
                 source->disp_name( true ) );
         } else {
             add_msg_player_or_npc(
                 m_warning,
                 _( "You avoid an incoming projectile!" ),
-                _( "<npcname> avoids an incoming projectile." ) );
+                get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? _( "<npcname> avoids an incoming projectile." ) :
+                "" );
         }
         return;
     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10619,19 +10619,22 @@ point game::place_player( const tripoint &dest_loc, bool quick )
                         and_the_rest += counts[i];
                     }
                 }
-                if( names.size() == 1 ) {
-                    add_msg( _( "You see here %s." ), names[0] );
-                } else if( names.size() == 2 ) {
-                    add_msg( _( "You see here %s and %s." ), names[0], names[1] );
-                } else if( names.size() == 3 ) {
-                    add_msg( _( "You see here %s, %s, and %s." ), names[0], names[1], names[2] );
-                } else if( and_the_rest < 7 ) {
-                    add_msg( n_gettext( "You see here %s, %s and %d more item.",
-                                        "You see here %s, %s and %d more items.",
-                                        and_the_rest ),
-                             names[0], names[1], and_the_rest );
-                } else {
-                    add_msg( _( "You see here %s and many more items." ), names[0] );
+
+                if( get_option<bool>( "LOG_ITEMS_ON_THE_GROUND" ) ) {
+                    if( names.size() == 1 ) {
+                        add_msg( _( "You see here %s." ), names[0] );
+                    } else if( names.size() == 2 ) {
+                        add_msg( _( "You see here %s and %s." ), names[0], names[1] );
+                    } else if( names.size() == 3 ) {
+                        add_msg( _( "You see here %s, %s, and %s." ), names[0], names[1], names[2] );
+                    } else if( and_the_rest < 7 ) {
+                        add_msg( n_gettext( "You see here %s, %s and %d more item.",
+                                            "You see here %s, %s and %d more items.",
+                                            and_the_rest ),
+                                 names[0], names[1], and_the_rest );
+                    } else {
+                        add_msg( _( "You see here %s and many more items." ), names[0] );
+                    }
                 }
             }
         }

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -26,6 +26,7 @@
 #include "monster.h"
 #include "mtype.h"
 #include "npc.h"
+#include "options.h"
 #include "point.h"
 #include "projectile.h"
 #include "ret_val.h"
@@ -295,7 +296,7 @@ bool leap_actor::call( monster &z ) const
     bool seen = player_view.sees( z ); // We can see them jump...
     z.setpos( chosen );
     seen |= player_view.sees( z ); // ... or we can see them land
-    if( seen ) {
+    if( seen && get_option<bool>( "LOG_MONSTER_MOVEMENT" ) ) {
         add_msg( message, z.name() );
     }
 
@@ -562,8 +563,9 @@ bool melee_actor::call( monster &z ) const
         game_message_type msg_type = target->is_avatar() ? m_warning : m_info;
         sfx::play_variant_sound( "mon_bite", "bite_miss", sfx::get_heard_volume( z.pos() ),
                                  sfx::get_heard_angle( z.pos() ) );
-        target->add_msg_player_or_npc( msg_type, miss_msg_u, miss_msg_npc, z.name(),
-                                       body_part_name_accusative( bp_id ) );
+        target->add_msg_player_or_npc( msg_type, miss_msg_u,
+                                       get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? miss_msg_npc : to_translation( "" ),
+                                       z.name(), body_part_name_accusative( bp_id ) );
         return true;
     }
 
@@ -572,8 +574,9 @@ bool melee_actor::call( monster &z ) const
             game_message_type msg_type = target->is_avatar() ? m_warning : m_info;
             sfx::play_variant_sound( "mon_bite", "bite_miss", sfx::get_heard_volume( z.pos() ),
                                      sfx::get_heard_angle( z.pos() ) );
-            target->add_msg_player_or_npc( msg_type, miss_msg_u, miss_msg_npc, mon_name,
-                                           body_part_name_accusative( bp_id ) );
+            target->add_msg_player_or_npc( msg_type, miss_msg_u,
+                                           get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? miss_msg_npc : to_translation( "" ),
+                                           mon_name, body_part_name_accusative( bp_id ) );
             return true;
         }
     }
@@ -614,8 +617,9 @@ bool melee_actor::call( monster &z ) const
     } else {
         sfx::play_variant_sound( "mon_bite", "bite_miss", sfx::get_heard_volume( z.pos() ),
                                  sfx::get_heard_angle( z.pos() ) );
-        target->add_msg_player_or_npc( m_neutral, no_dmg_msg_u, no_dmg_msg_npc, mon_name,
-                                       body_part_name_accusative( bp_id ) );
+        target->add_msg_player_or_npc( m_neutral, no_dmg_msg_u,
+                                       get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? no_dmg_msg_npc : to_translation( "" ),
+                                       mon_name, body_part_name_accusative( bp_id ) );
         if( !effects_require_dmg ) {
             for( const mon_effect_data &eff : effects ) {
                 if( x_in_y( eff.chance, 100 ) ) {
@@ -631,7 +635,9 @@ bool melee_actor::call( monster &z ) const
         z.remove_effect( effect_grabbing );
         g->fling_creature( target, coord_to_angle( z.pos(), target->pos() ),
                            throw_strength );
-        target->add_msg_player_or_npc( m_bad, throw_msg_u, throw_msg_npc, mon_name );
+        target->add_msg_player_or_npc( m_bad, throw_msg_u,
+                                       get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? throw_msg_npc : to_translation( "" ),
+                                       mon_name );
 
         // Items strapped to you may fall off as you hit the ground
         // when you break out of a grab you have a chance to lose some things from your pockets
@@ -675,8 +681,9 @@ void melee_actor::on_damage( monster &z, Creature &target, dealt_damage_instance
     const bodypart_id &bp = dealt.bp_hit ;
     const std::string mon_name = get_player_character().sees( z.pos() ) ?
                                  z.disp_name( false, true ) : _( "Something" );
-    target.add_msg_player_or_npc( msg_type, hit_dmg_u, hit_dmg_npc, mon_name,
-                                  body_part_name_accusative( bp ) );
+    target.add_msg_player_or_npc( msg_type, hit_dmg_u,
+                                  get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? hit_dmg_npc : to_translation( "" ),
+                                  mon_name, body_part_name_accusative( bp ) );
 
     for( const mon_effect_data &eff : effects ) {
         if( x_in_y( eff.chance, 100 ) ) {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -37,6 +37,7 @@
 #include "monster_oracle.h"
 #include "mtype.h"
 #include "npc.h"
+#include "options.h"
 #include "pathfinding.h"
 #include "pimpl.h"
 #include "rng.h"
@@ -1658,15 +1659,19 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
             if( flies() ) {
                 moves -= 100;
                 force = true;
-                add_msg_if_player_sees( *this, _( "The %1$s flies over the %2$s." ), name(),
-                                        here.has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, p ) ? here.furnname( p ) :
-                                        here.tername( p ) );
+                if( get_option<bool>( "LOG_MONSTER_MOVEMENT" ) ) {
+                    add_msg_if_player_sees( *this, _( "The %1$s flies over the %2$s." ), name(),
+                                            here.has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, p ) ? here.furnname( p ) :
+                                            here.tername( p ) );
+                }
             } else if( climbs() ) {
                 moves -= 150;
                 force = true;
-                add_msg_if_player_sees( *this, _( "The %1$s climbs over the %2$s." ), name(),
-                                        here.has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, p ) ? here.furnname( p ) :
-                                        here.tername( p ) );
+                if( get_option<bool>( "LOG_MONSTER_MOVEMENT" ) ) {
+                    add_msg_if_player_sees( *this, _( "The %1$s climbs over the %2$s." ), name(),
+                                            here.has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, p ) ? here.furnname( p ) :
+                                            here.tername( p ) );
+                }
             }
         }
     }
@@ -1705,26 +1710,28 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
             has_flag( MF_AQUATIC ) || ( can_submerge() && !here.veh_at( destination ) )
         ) && here.is_divable( destination );
 
-    //Birds and other flying creatures flying over the deep water terrain
-    if( was_water && flies() ) {
-        if( one_in( 4 ) ) {
-            add_msg_if_player_sees( *this, m_warning, _( "A %1$s flies over the %2$s!" ),
-                                    name(), here.tername( pos() ) );
+    if( get_option<bool>( "LOG_MONSTER_MOVEMENT" ) ) {
+        //Birds and other flying creatures flying over the deep water terrain
+        if( was_water && flies() ) {
+            if( one_in( 4 ) ) {
+                add_msg_if_player_sees( *this, m_warning, _( "A %1$s flies over the %2$s!" ),
+                                        name(), here.tername( pos() ) );
+            }
+        } else if( was_water && !will_be_water ) {
+            // Use more dramatic messages for swimming monsters
+            add_msg_if_player_sees( *this, m_warning,
+                                    //~ Message when a monster emerges from water
+                                    //~ %1$s: monster name, %2$s: leaps/emerges, %3$s: terrain name
+                                    pgettext( "monster movement", "A %1$s %2$s from the %3$s!" ),
+                                    name(), swims() || has_flag( MF_AQUATIC ) ? _( "leaps" ) : _( "emerges" ), here.tername( pos() ) );
+        } else if( !was_water && will_be_water ) {
+            add_msg_if_player_sees( *this, m_warning, pgettext( "monster movement",
+                                    //~ Message when a monster enters water
+                                    //~ %1$s: monster name, %2$s: dives/sinks, %3$s: terrain name
+                                    "A %1$s %2$s into the %3$s!" ),
+                                    name(), swims() ||
+                                    has_flag( MF_AQUATIC ) ? _( "dives" ) : _( "sinks" ), here.tername( destination ) );
         }
-    } else if( was_water && !will_be_water ) {
-        // Use more dramatic messages for swimming monsters
-        add_msg_if_player_sees( *this, m_warning,
-                                //~ Message when a monster emerges from water
-                                //~ %1$s: monster name, %2$s: leaps/emerges, %3$s: terrain name
-                                pgettext( "monster movement", "A %1$s %2$s from the %3$s!" ),
-                                name(), swims() || has_flag( MF_AQUATIC ) ? _( "leaps" ) : _( "emerges" ), here.tername( pos() ) );
-    } else if( !was_water && will_be_water ) {
-        add_msg_if_player_sees( *this, m_warning, pgettext( "monster movement",
-                                //~ Message when a monster enters water
-                                //~ %1$s: monster name, %2$s: dives/sinks, %3$s: terrain name
-                                "A %1$s %2$s into the %3$s!" ),
-                                name(), swims() ||
-                                has_flag( MF_AQUATIC ) ? _( "dives" ) : _( "sinks" ), here.tername( destination ) );
     }
 
     optional_vpart_position vp_orig = here.veh_at( pos() );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1743,7 +1743,7 @@ bool monster::melee_attack( Creature &target, float accuracy )
             } else if( target.is_npc() && target_dodging ) {
                 add_msg( _( "%1$s dodges %2$s attack." ),
                          target.disp_name(), u_see_me ? name() : _( "something" ) );
-            } else {
+            } else if( get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ) {
                 add_msg( _( "%1$s misses %2$s!" ),
                          u_see_me ? disp_name( false, true ) : _( "Something" ), target.disp_name() );
             }
@@ -1779,13 +1779,15 @@ bool monster::melee_attack( Creature &target, float accuracy )
                     add_msg( m_good, _( "Your %1$s hits %2$s for %3$d damage!" ), get_name(), target.disp_name(),
                              total_dealt );
                 }
-                if( !u_see_me && u_see_target ) {
-                    add_msg( _( "Something hits the %1$s!" ), target.disp_name() );
-                } else if( !u_see_target ) {
-                    add_msg( _( "The %1$s hits something!" ), name() );
-                } else {
-                    //~ %1$s: attacker name, %2$s: target creature name
-                    add_msg( _( "The %1$s hits %2$s!" ), name(), target.disp_name() );
+                if( get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ) {
+                    if( !u_see_me && u_see_target ) {
+                        add_msg( _( "Something hits the %1$s!" ), target.disp_name() );
+                    } else if( !u_see_target ) {
+                        add_msg( _( "The %1$s hits something!" ), name() );
+                    } else {
+                        //~ %1$s: attacker name, %2$s: target creature name
+                        add_msg( _( "The %1$s hits %2$s!" ), name(), target.disp_name() );
+                    }
                 }
             }
         } else if( target.is_avatar() ) {
@@ -1811,7 +1813,7 @@ bool monster::melee_attack( Creature &target, float accuracy )
                          body_part_name_accusative( dealt_dam.bp_hit ),
                          target.disp_name( true ),
                          target.skin_name() );
-            } else {
+            } else if( get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ) {
                 //~ $1s is monster name, %2$s is that monster target name,
                 //~ $3s is target armor name.
                 add_msg( _( "%1$s hits %2$s but is stopped by its %3$s." ),
@@ -2023,7 +2025,7 @@ bool monster::move_effects( bool )
         bool immediate_break = type->in_species( species_FISH ) || type->in_species( species_MOLLUSK ) ||
                                type->in_species( species_ROBOT ) || type->bodytype == "snake" || type->bodytype == "blob";
         if( !immediate_break && rng( 0, 900 ) > type->melee_dice * type->melee_sides * 1.5 ) {
-            if( u_see_me ) {
+            if( u_see_me && get_option<bool>( "LOG_MONSTER_MOVE_EFFECTS" ) ) {
                 add_msg( _( "The %s struggles to break free of its bonds." ), name() );
             }
         } else if( immediate_break ) {
@@ -2057,11 +2059,11 @@ bool monster::move_effects( bool )
     }
     if( has_effect( effect_downed ) ) {
         if( rng( 0, 40 ) > type->melee_dice * type->melee_sides * 1.5 ) {
-            if( u_see_me ) {
+            if( u_see_me && get_option<bool>( "LOG_MONSTER_MOVE_EFFECTS" ) ) {
                 add_msg( _( "The %s struggles to stand." ), name() );
             }
         } else {
-            if( u_see_me ) {
+            if( u_see_me && get_option<bool>( "LOG_MONSTER_MOVE_EFFECTS" ) ) {
                 add_msg( _( "The %s climbs to its feet!" ), name() );
             }
             remove_effect( effect_downed );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1735,6 +1735,34 @@ void options_manager::add_options_interface()
 
     add_empty_line();
 
+    add_option_group( "interface", Group( "additional_messages_in_log",
+                                          to_translation( "Additional messages in the log" ),
+                                          to_translation( "If true, some additional messages will be shown in the message log." ) ),
+    [&]( const std::string & page_id ) {
+
+        add( "LOG_ITEMS_ON_THE_GROUND", page_id, to_translation( "Items on the ground" ),
+             to_translation( "Show info about items lying on the ground when character steps on tile with them." ),
+             true
+           );
+
+        add( "LOG_MONSTER_MOVEMENT", page_id, to_translation( "Special monster movement" ),
+             to_translation( "Show messages about special monster movement: flying over the fence, diving into the water etc." ),
+             true
+           );
+
+        add( "LOG_MONSTER_MOVE_EFFECTS", page_id, to_translation( "Monster attempts to free itself" ),
+             to_translation( "Show messages about monster trying to free itself from effect preventing it from moving: downed, tied etc." ),
+             true
+           );
+
+        add( "LOG_MONSTER_ATTACK_MONSTER", page_id, to_translation( "Monster/NPC attacking monster/NPC" ),
+             to_translation( "Show messages about non-playable creatures attacking other non-playable creatures." ),
+             true
+           );
+    } );
+
+    add_empty_line();
+
     add( "SHOW_GUN_VARIANTS", "interface", to_translation( "Show gun brand names" ),
          to_translation( "If true, show brand names for guns, instead of generic functional names - 'm4a1' or 'h&k416a5' instead of 'NATO assault rifle'." ),
          false );


### PR DESCRIPTION
#### Summary
Interface "Enable/disable showing several non-player-related messages in the log"

#### Purpose of change
Currently message log is spammed by tons of potentially unneeded information, such as "monster misses other monster" or "duck flies over the fence". I am very annoyed by such message spam, so I added an option group when player can enable or disable showing of such information.

#### Describe the solution
- Added 'Additional messages in the log' option group
- Added options for showing/hiding messages for
- - "You see here x items" when player steps on tile with items
- - "Monster flies over the fence"-type of messages
- - "Monster leaps!"
- - Monster struggles to stand up after being knocked down
- - Monster/NPC hits/misses/bites/lunges/claws/throws other monster/NPC
- - Monster/NPC avoids incoming projectile from other monster/NPC
- All options defaults to true.

#### Describe alternatives you've considered
None.

#### Testing
Turned all options off, teleported into a city. No more message spam, until occasional "monster dies" or "you hear a crash".

#### Additional context
![изображение](https://user-images.githubusercontent.com/11132525/230767867-9aa9b795-4ffb-4650-826e-143e86c17fb1.png)

If there's some other message you want to hide, please tell me, I'll try to hide it under an option.