### PR TITLE
Improve items on the ground message code

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10562,12 +10562,10 @@ point game::place_player( const tripoint &dest_loc, bool quick )
     }
 
     // List items here
-    if( !quick && !m.has_flag( ter_furn_flag::TFLAG_SEALED, u.pos() ) ) {
+    if( !quick && !m.has_flag( ter_furn_flag::TFLAG_SEALED, u.pos() ) && get_option<bool>( "LOG_ITEMS_ON_THE_GROUND" ) ) {
         if( get_option<bool>( "NO_AUTO_PICKUP_ZONES_LIST_ITEMS" ) ||
             !check_zone( zone_type_NO_AUTO_PICKUP, u.pos() ) ) {
-            if( u.is_blind() && !m.i_at( u.pos() ).empty() ) {
-                add_msg( _( "There's something here, but you can't see what it is." ) );
-            } else if( m.has_items( u.pos() ) ) {
+            if( m.has_items( u.pos() ) ) {
                 std::vector<std::string> names;
                 std::vector<size_t> counts;
                 std::vector<item> items;
@@ -10620,21 +10618,19 @@ point game::place_player( const tripoint &dest_loc, bool quick )
                     }
                 }
 
-                if( get_option<bool>( "LOG_ITEMS_ON_THE_GROUND" ) ) {
-                    if( names.size() == 1 ) {
-                        add_msg( _( "You see here %s." ), names[0] );
-                    } else if( names.size() == 2 ) {
-                        add_msg( _( "You see here %s and %s." ), names[0], names[1] );
-                    } else if( names.size() == 3 ) {
-                        add_msg( _( "You see here %s, %s, and %s." ), names[0], names[1], names[2] );
-                    } else if( and_the_rest < 7 ) {
-                        add_msg( n_gettext( "You see here %s, %s and %d more item.",
-                                            "You see here %s, %s and %d more items.",
-                                            and_the_rest ),
-                                 names[0], names[1], and_the_rest );
-                    } else {
-                        add_msg( _( "You see here %s and many more items." ), names[0] );
-                    }
+                if( names.size() == 1 ) {
+                    add_msg( u.is_blind() ? _( "You notice %s here." ) : _( "You see %s here." ), names[0] );
+                } else if( names.size() == 2 ) {
+                    add_msg( u.is_blind() ? _( "You notice %s and %s here." ) : _( "You see %s and %s here." ), names[0], names[1] );
+                } else if( names.size() == 3 ) {
+                    add_msg( u.is_blind() ? _( "You notice %s, %s, and %s here." ) : _( "You see %s, %s, and %s here." ), names[0], names[1], names[2] );
+                } else if( and_the_rest < 9 ) {
+                    add_msg( n_gettext( u.is_blind() ? "You notice %s, %s and %d other item here." : "You see %s, %s and %d other item here.",
+                                        u.is_blind() ? "You notice %s, %s and %d other items here." : "You see %s, %s and %d other items here.",
+                                        and_the_rest ),
+                             names[0], names[1], and_the_rest );
+                } else {
+                    add_msg( u.is_blind() ? _( "You notice %s, %s and more than 8 other items here." ) : _( "You see %s, %s and more than 8 other items here." ), names[0], names[1] );
                 }
             }
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Improve items on the ground message code"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Improving usefulness of the messages provided while moving into a tile with items.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Moved an option check earlier in the code, so that pointless calculations aren't done if the option is set to not show items on the ground while stepping on the tiles.

Allowed blind characters to get a more detailed message about items on the tile that they've just stepped into. Considering that they can already use a "grab items" command to get a list of items on this tile (as well as adjacent ones), this isn't really an exploit but may save an unnecessary keypress for the player if their character is blind.

Rewrote displayed messages to be slightly more clear as on to how many items are actually on the tile, at least as far as  current limitations (presumably for performance reasons) allow.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Always displaying exact number of items on the tile regardless of their amount, but this may negatively impact performance.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Walked on a tile with items, made sure that the message is displayed only with the option on, and that the information displayed is correct.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
None.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->