### PR TITLE
Fix segfault risks stemming from last_world_pos

### DIFF
--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -612,13 +612,8 @@ bool main_menu::opening_screen()
 
     // Make [Load Game] the default cursor position if there's game save available
     if( !world_generator->get_all_worlds().empty() ) {
-        std::vector<std::string> worlds = world_generator->all_worldnames();
-        last_world_pos = world_generator->get_world_index( world_generator->last_world_name );
-        if( last_world_pos >= worlds.size() ) {
-            last_world_pos = 0;
-        }
         sel1 = getopt( main_menu_opts::LOADCHAR );
-        sel2 = last_world_pos;
+        sel2 = world_generator->get_world_index( world_generator->last_world_name );
     }
 
     background_pane background;
@@ -646,6 +641,9 @@ bool main_menu::opening_screen()
 
     while( !start ) {
         ui_manager::redraw();
+        // Refresh in case player created new world or deleted old world
+        // Since this is an index for a mutable array, it should always be regenerated instead of modified.
+        const size_t last_world_pos = world_generator->get_world_index( world_generator->last_world_name );
         std::string action = ctxt.handle_input();
         input_event sInput = ctxt.get_raw_input();
 
@@ -1114,10 +1112,6 @@ void main_menu::world_tab( const std::string &worldname )
     // Create world
     if( sel2 == 0 ) {
         WORLD *world = world_generator->make_new_world();
-        // NOLINTNEXTLINE(cata-use-localized-sorting)
-        if( world != nullptr && world->world_name < world_generator->all_worldnames()[last_world_pos] ) {
-            last_world_pos++;
-        }
         return;
     }
 
@@ -1139,10 +1133,6 @@ void main_menu::world_tab( const std::string &worldname )
 
     auto clear_world = [this, &worldname]( bool do_delete ) {
         world_generator->delete_world( worldname, do_delete );
-        // NOLINTNEXTLINE(cata-use-localized-sorting)
-        if( last_world_pos > 0 && worldname <= world_generator->all_worldnames()[last_world_pos] ) {
-            last_world_pos--;
-        }
         savegames.clear();
         MAPBUFFER.clear();
         overmap_buffer.clear();

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -1111,7 +1111,7 @@ void main_menu::world_tab( const std::string &worldname )
 {
     // Create world
     if( sel2 == 0 ) {
-        WORLD *world = world_generator->make_new_world();
+        world_generator->make_new_world();
         return;
     }
 

--- a/src/main_menu.h
+++ b/src/main_menu.h
@@ -72,7 +72,6 @@ class main_menu
         input_context ctxt;
         int sel1 = 1;
         int sel2 = 1;
-        size_t last_world_pos = 0;
         int sub_opt_off = 0;
         point LAST_TERM;
         catacurses::window w_open;


### PR DESCRIPTION
#### Summary

Bugfixes "Fix segfault risks stemming from last_world_pos"

#### Purpose of change

- CleverRaven/Cataclysm-DDA#64795 and subsequently CleverRaven/Cataclysm-DDA#65124 used a somewhat awkward method to update last_world_pos that caused segfaults.
- Current known segfault behaviour stems from deleting a world that would cause the current index to go out of bounds. Can be replicated as follows.
  - Create at least 2 worlds, and create a character in the world at the bottom of the list. Save and exit. On returning to the main menu, delete any world except the world with the character.

In general, I believe that derived indexes should only be regenerated instead of modified, as this prevents any risk of segfaults and keeps the code easy to follow.

In a similar vein, I don't believe that such indexes should be saved as class variables, as you will need to remember to update them every single time you code for dependent value changes instead of letting it be regenerated.

#### Describe the solution

Several redundant checks were removed, as the nature of `get_world_index()` means that it cannot go out of bounds.
- It iterates down the list of all worlds, so the returned value can never be greater than the size of all worlds - 1.
- If it cannot find a name it returns 0, which points to the first world.

Now, every redraw, `last_world_pos` is regenerated to account for the possibility of worlds being added or deleted. The performance overhead of this is considered negligible, as number of worlds generally will never reach a point where a human perceptible slowdown can be noticed unless they're running it on an electronic birthday card.

Removed `last_world_pos` from `main_menu` class.

#### Describe alternatives you've considered

- Regenerate `last_world_pos` only when world is created/destroyed.
  - Would be more performant, but as I consider the boost to be generally negligible, I've elected against it.

#### Testing

- [x] Create 5 worlds, and make a character in the third world. Save and return to the main menu. 
- [x] Check that pointer when in load menu defaults to the third world. Move to world tab and delete either world 1/2
- [x] Check that it still defaults to the correct world when in load menu. Move to world tab and delete one of the last 2 worlds
- [x] Check that it still defaults to the correct world when in load menu.

#### Additional context