### PR TITLE
Исправление начального экрана

### DIFF
--- a/data/title/en.alt1
+++ b/data/title/en.alt1
@@ -7,18 +7,18 @@
 <color_light_cyan>   \     \____ / __ \_ |  |   / __ \_\  \___ |  |__ \___  | \___ \ |  Y Y  \    </color>
 <color_light_cyan>    \______  /(____  / |__|  (____  / \___  >|____/ / ____|/____  >|__|_|  /    </color>
 <color_light_cyan>           \/      \/             \/      \/        \/          \/       \/     </color>
-<color_light_blue>    ________                   .__      ________                                </color>
-<color_light_blue>    \______ \  _____   _______ |  | __  \______ \  _____    ___.__   ______     </color>
-<color_light_blue>     |    |  \ \__  \  \_  __ \|  |/ /   |    |  \ \__  \  <   |  | /  ___/     </color>
-<color_light_blue>     |    `   \ / __ \_ |  | \/|    <    |    `   \ / __ \_ \___  | \___ \      </color>
-<color_light_blue>    /_______  /(____  / |__|   |__|_ \  /_______  /(____  / / ____|/____  >     </color>
-<color_light_blue>            \/      \/              \/          \/      \/  \/          \/      </color>
-<color_light_blue>                     _____   .__                         .___                   </color>
-<color_light_blue>                    /  _  \  |  |__    ____  _____     __| _/                   </color>
-<color_light_blue>                   /  /_\  \ |  |  \ _/ __ \ \__  \   / __ |                    </color>
-<color_light_blue>                  /    |    \|   Y  \\  ___/  / __ \_/ /_/ |              </color><color_light_green>.-.   </color>
-<color_light_blue>                  \____|__  /|___|  / \___  >(____  /\____ |          </color><color_light_green>_  |   `  </color>
-<color_light_blue>                          \/      \/      \/      \/      \/           </color><color_light_green>',|    \ </color>
+<color_light_blue>               _________                   ______           </color>
+<color_light_blue>              /   _____/_______ _____     /  __  \   ____   </color>
+<color_light_blue>              |   |___  \_  __ \\__  \    |  | | |  /  _ \  </color>
+<color_light_blue>              |   ___/   |  | \/ / __ \_  |  | | | _| |_\/  </color>
+<color_light_blue>              |   |____  |__|   (____  /  |  |_| | \_ __\   </color>
+<color_light_blue>              \_______/              \/   \______/  |_/     </color>
+<color_light_blue>              ________                                          </color>
+<color_light_blue>              \______ \    ____    ____  _____   ___.__         </color>
+<color_light_blue>               |    |  \ _/ __ \ _/ ___\ \__  \ <   |  |        </color>
+<color_light_blue>               |        \\  ___/ \  \___  / __ \_\___  |        </color>         <color_light_green>.-.   </color>
+<color_light_blue>              /_______  / \___  > \___  >(____  // ____|        </color>      <color_light_green>_  |   `  </color>
+<color_light_blue>                      \/      \/      \/      \/ \/             </color>       <color_light_green>',|    \ </color>
 <color_white>     ***                                                  </color><color_light_green>_..        -.,,'-., / </color>
 <color_white>    *   *  /-\                                       </color><color_light_green>,,,,/   |           |    \ </color>
 <color_white>     *** =========='      </color><color_red>----               ----        </color><color_light_green>`  _/`'.,       \ _--  </color>

--- a/data/title/ru.alt1
+++ b/data/title/ru.alt1
@@ -4,18 +4,18 @@
 <color_light_cyan>    |    |  \  / __ \_ |  |   / __ \_|    <  /  Y  \|  /  | _(__  <|  Y Y  \    </color>
 <color_light_cyan>    |____|__ \(____  / |__|  (____  /|__|_ \|___|  /\__/  //____  /|__|_|  /    </color>
 <color_light_cyan>            \/     \/             \/      \/     \/     \/      \/       \/     </color>
-<color_light_blue>  ___________ ..                                       ______                   </color>
-<color_light_blue>  \__    ___/____    __ __  ___ __  __   __   ____     \___  \  ___ __  __ __   </color>
-<color_light_blue>    |    | _/ __ \  /  V  \ \  |  ||  |_|  |_/ __ \    /  /|  \ \  |  ||  |  |  </color>
-<color_light_blue>    |    | \  ___/ |  Y Y  \|     ||  _ \  |\  ___/  _/  /_|   \|     ||  /  |  </color>
-<color_light_blue>    |____|  \___  >|__|_|  /|__|  ||____/__| \___  > \  _____  /|__|  |\__/  /  </color>
-<color_light_blue>                \/       \/     \/               \/   \/     \/     \/     \/   </color>
-<color_light_blue>           __________                                                           </color>
-<color_light_blue>           \______   \ ______   ____ _______    ____     __    __ __            </color>
-<color_light_blue>            |    |  _/ \     |_/ __ \\____  \ _/ __ \   /  \  |  |  |           </color>
-<color_light_blue>            |    |)  \ |  Y  |\  ___/ |  |)  >\  ___/ _/ /\ \_|  /  |     </color><color_light_green>.-.   </color>
-<color_light_blue>            |______  / |__|  / \___  >|   __/  \___  >\  __  /\__/  / </color><color_light_green>_  </color><color_light_green>|   `  </color>
-<color_light_blue>                   \/      \/      \/ |__|         \/  \/  \/     \/   </color><color_light_green>',|    \ </color>
+<color_light_green>                            ___________                                         </color>
+<color_light_green>                            \_________ \ _______  _____                         </color>
+<color_light_green>                               ______| | \____  \ \__  \                        </color>
+<color_light_green>                               \______ |  |  |)  > / __ \_                      </color>
+<color_light_green>                            ________/  |  |  ___/ (____  /                      </color>
+<color_light_green>                            \__________/  |__|         \/                       </color>
+<color_light_green>           _________                                                        </color>
+<color_light_green>          /_______  \ _____     ____  ______ _____   _____    _____          </color>
+<color_light_green>            |  |__)  >\__  \  _/ ___\ \     |\__  \  \__  \   \__  \        </color>
+<color_light_green>            |   ____/  / __ \_\  \___ |  Y  | / __ \_ / \_ \_  / __ \_    </color><color_light_green>.-.   </color>
+<color_light_green>            |  |      (____  / \___  >|__|  /(____  // ____  /(____  /</color><color_light_green>_  </color><color_light_green>|   `  </color>
+<color_light_green>            |__|           \/      \/     \/      \/ \/    \/      \/   </color><color_light_green>',|    \ </color>
 <color_white>     ***                                                  </color><color_light_green>_..        -.,,'-., / </color>
 <color_white>    *   *  /-\                                       </color><color_light_green>,,,,/   |           |    \ </color>
 <color_white>     *** =========='      </color><color_red>----               ----        </color><color_light_green>`  _/`'.,       \ _--  </color>

--- a/data/title/ru.alt1
+++ b/data/title/ru.alt1
@@ -15,7 +15,7 @@
 <color_light_green>            |  |__)  >\__  \  _/ ___\ \     |\__  \  \__  \   \__  \        </color>
 <color_light_green>            |   ____/  / __ \_\  \___ |  Y  | / __ \_ / \_ \_  / __ \_    </color><color_light_green>.-.   </color>
 <color_light_green>            |  |      (____  / \___  >|__|  /(____  // ____  /(____  /</color><color_light_green>_  </color><color_light_green>|   `  </color>
-<color_light_green>            |__|           \/      \/     \/      \/ \/    \/      \/   </color><color_light_green>',|    \ </color>
+<color_light_green>            |__|           \/      \/     \/      \/ \/    \/      \/  </color><color_light_green>',|    \ </color>
 <color_white>     ***                                                  </color><color_light_green>_..        -.,,'-., / </color>
 <color_white>    *   *  /-\                                       </color><color_light_green>,,,,/   |           |    \ </color>
 <color_white>     *** =========='      </color><color_red>----               ----        </color><color_light_green>`  _/`'.,       \ _--  </color>


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

Заметил что альт экран все еще говорит про дда, вот и меняем на еод

#### Purpose of change

Изменение альтернативного начального экрана, для того чтобы он говорил про еод

#### Describe the solution

Провести слияние

#### Describe alternatives you've considered

Сделать по своему

#### Testing

поставить шанс альт экрана 100% и перезапустить игру
![image](https://github.com/AtomicFox556/Cataclysm-EOD/assets/120565475/f862c53a-f251-4cfa-98af-6dc54308482c)
![image](https://github.com/AtomicFox556/Cataclysm-EOD/assets/120565475/0a60c6b0-1d17-4926-bb64-08b4d987a9ed)



#### Additional context
Цвета брал из основных экранов, и мне стало интересно, а почему ру зеленый, а енг синий?
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->