### PR TITLE
Port "Uncanny dodge spell fix"

### DIFF
--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -532,31 +532,31 @@ static void damage_targets( const spell &sp, Creature &caster,
 
         dealt_projectile_attack atk = sp.get_projectile_attack( target, *cr, caster );
         const int spell_accuracy = sp.accuracy( caster );
-        double damage_mitigation_multiplier = 1.0;
-        if( const int spell_block = cr->get_block_bonus() - spell_accuracy > 0 ) {
-            const int roll = std::round( rng( 1, 20 ) );
-            // 5% per point (linear) ranging from 0-33%, capped at block score
-            damage_mitigation_multiplier -= ( 1 - 0.05 * std::max( roll, spell_block ) ) / 3.0;
-        }
-
-        if( cr->dodge_check( spell_accuracy ) ) {
-            const int spell_dodge = cr->get_dodge() - spell_accuracy;
-            const int roll = std::round( rng( 1, 20 ) );
-            // 5% per point (linear) ranging from 0-33%, capped at block score
-            damage_mitigation_multiplier -= ( 1 - 0.05 * std::max( roll, spell_dodge ) ) / 3.0;
-        }
-
-        if( const int spell_resist = cr->get_spell_resist() - spell_accuracy > 0 &&
-                                     !sp.has_flag( spell_flag::NON_MAGICAL ) ) {
-            const int roll = std::round( rng( 1, 20 ) );
-            // 5% per point (linear) ranging from 0-33%, capped at block score
-            damage_mitigation_multiplier -= ( 1 - 0.05 * std::max( roll, spell_resist ) ) / 3.0;
-        }
 
         if( !sp.effect_data().empty() ) {
             add_effect_to_target( target, sp, caster );
         }
         if( sp.damage( caster ) > 0 ) {
+            // calculate damage mitigation from various sources
+            // 5% per point (linear) ranging from 0-33%, capped at block score
+            double damage_mitigation_multiplier = 1.0;
+            if( const int spell_block = cr->get_block_bonus() - spell_accuracy > 0 ) {
+                const int roll = std::round( rng( 1, 20 ) );
+                damage_mitigation_multiplier -= ( 1 - 0.05 * std::max( roll, spell_block ) ) / 3.0;
+            }
+
+            if( cr->dodge_check( spell_accuracy ) ) {
+                const int spell_dodge = cr->get_dodge() - spell_accuracy;
+                const int roll = std::round( rng( 1, 20 ) );
+                damage_mitigation_multiplier -= ( 1 - 0.05 * std::max( roll, spell_dodge ) ) / 3.0;
+            }
+
+            if( const int spell_resist = cr->get_spell_resist() - spell_accuracy > 0 &&
+                                         !sp.has_flag( spell_flag::NON_MAGICAL ) ) {
+                const int roll = std::round( rng( 1, 20 ) );
+                damage_mitigation_multiplier -= ( 1 - 0.05 * std::max( roll, spell_resist ) ) / 3.0;
+            }
+
             for( damage_unit &val : atk.proj.impact.damage_units ) {
                 if( sp.has_flag( spell_flag::PERCENTAGE_DAMAGE ) ) {
                     val.amount = cr->get_hp( cr->get_root_body_part() ) * sp.damage( caster ) / 100.0;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2970,10 +2970,12 @@ void options_manager::add_options_world_default()
          to_translation( "If true, radiation causes the player to mutate." ),
          false
        );
-    add( "SHOW_MUTATION_SELECTOR", "world_default", to_translation( "Mutation Selector" ),
-         to_translation( "If true, when mutating, allows you to pick from a list of possible mutations instead of getting one at random.." ),
+
+    add( "SHOW_MUTATION_SELECTOR", "world_default", to_translation( "Selectable mutations" ),
+         to_translation( "If true, mutating lets you pick a mutation from a list of possible mutations.  If false, mutations gained are random." ),
          false
        );
+
     add_empty_line();
 
     add( "ENABLE_ROBOT_RESPONSE", "world_default", to_translation( "Robot alarm response" ),


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Stop dodging good spells, fix uncanny dodge spell crash"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Port https://github.com/CleverRaven/Cataclysm-DDA/pull/67218 as per request on Discord.

Right now, game attempts to calculate damage mitigation values for any spell, including non-damaging ones and healing spells. Since dodge check actually triggers uncanny dodge, this would lead to moving to a different tile during the execution, then trying to apply effect to a tripoint (which character moved from). Result: segfault.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Add effects to the spell targets before dodge can happen
- Do not attempt to dodge if spell is not harmful

We no longer calculate mitigation values for non-damaging spells. This solves the dodge attempt issue. Spell effects are now applied before calculating the mitigation values, which solves the segfault.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
1. Disabling dodge calculations for spells completely.
2. Using effect rating (bad/good) to determine whether the spell should be attempted to dodge.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
